### PR TITLE
[Vacalyser/Docs] Add agent guide and env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+secrets.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Vacalyser AGENTS Guide
+
+This project is a slim demonstration of the Vacalyser workflow. Use this file as a quick reference for environment setup and contributor rules.
+
+## Environment Variables
+Set non-secret configuration in a `.env` file and read them using `os.environ.get()` in Python. Typical variables:
+
+- `STREAMLIT_ENV` – switch between `development` and `production`.
+- `LANGUAGE` – default UI language (`en` or `de`).
+- `MODEL_PROVIDER` – model backend (`openai` or `ollama`).
+- `DEFAULT_MODEL` – default model name for the provider.
+- `VECTOR_STORE_PATH` – path to your vector database directory.
+
+Use these variables for conditional logic or configuration switching.
+
+## Secrets
+Keep secrets out of version control. Store them in `secrets.toml` (for Streamlit) or a cloud secret manager.
+
+Required secrets include:
+
+- `OPENAI_API_KEY`
+- `OPENAI_ORG_ID`
+- `OLLAMA_API_KEY`
+- `DATABASE_URL`
+- `SECRET_KEY`
+
+Never log or print these values.
+
+## Setup Script
+Before running the app locally:
+
+```bash
+pip install -r requirements.txt
+python scripts/download_models.py    # if models are needed
+```
+
+Ensure directories such as `uploads/` and `logs/` exist. Then start the app with `streamlit run app.py`.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,15 @@ Set non-secret configuration in a `.env` file and read them using `os.environ.ge
 - `DEFAULT_MODEL` – default model name for the provider.
 - `VECTOR_STORE_PATH` – path to your vector database directory.
 
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| STREAMLIT_ENV | development | environment switch |
+| LANGUAGE | en | default UI language |
+| MODEL_PROVIDER | openai | LLM backend |
+| DEFAULT_MODEL | gpt-4o | base model name |
+| VECTOR_STORE_PATH | ./vector_store | path to vector DB |
+
 Use these variables for conditional logic or configuration switching.
 
 ## Secrets
@@ -35,4 +44,12 @@ python scripts/download_models.py    # if models are needed
 ```
 
 Ensure directories such as `uploads/` and `logs/` exist. Then start the app with `streamlit run app.py`.
+
+
+## Special AI Prompt Guidance
+- Provide clear context about the job role and known session data.
+- Use structured prompts like "Extract all available keys ..." for extraction tasks.
+- When a key is missing, generate a follow-up question using wording from `data/question_nodes.yml`.
+- Include company, team and skill requirements in candidate sourcing prompts.
+- Adapt prompts to the chosen LANGUAGE if the job ad is multilingual.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Set these variables in a `.env` file or your deployment environment. Read them i
 - `DEFAULT_MODEL` – model name used by the provider (e.g. `gpt-4o`).
 - `VECTOR_STORE_PATH` – path to the vector database directory.
 
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| STREAMLIT_ENV | development | environment switch |
+| LANGUAGE | en | default UI language |
+| MODEL_PROVIDER | openai | LLM backend |
+| DEFAULT_MODEL | gpt-4o | base model name |
+| VECTOR_STORE_PATH | ./vector_store | path to vector DB |
+
+
 ## Secrets
 
 Sensitive values must never be committed. Use `secrets.toml` (for Streamlit) or your cloud secret manager for:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# 06_05_25_gpt_slim
+# Vacalyser
+
+This repository contains a slim demo of the Vacalyser app. The app uses Streamlit and relies on a few environment variables for configuration.
+
+## Environment Variables
+
+Set these variables in a `.env` file or your deployment environment. Read them in Python via `os.environ.get("VAR_NAME")`.
+
+- `STREAMLIT_ENV` – `development` or `production` to toggle features.
+- `LANGUAGE` – default UI language (`en` or `de`).
+- `MODEL_PROVIDER` – which LLM backend to use (`openai` or `ollama`).
+- `DEFAULT_MODEL` – model name used by the provider (e.g. `gpt-4o`).
+- `VECTOR_STORE_PATH` – path to the vector database directory.
+
+## Secrets
+
+Sensitive values must never be committed. Use `secrets.toml` (for Streamlit) or your cloud secret manager for:
+
+- `OPENAI_API_KEY`
+- `OPENAI_ORG_ID`
+- `OLLAMA_API_KEY`
+- `DATABASE_URL`
+- `SECRET_KEY`
+
+Ensure `secrets.toml` is excluded via `.gitignore`.
+
+## Setup
+
+Install dependencies and prepare local models before running the app:
+
+```bash
+pip install -r requirements.txt
+python scripts/download_models.py  # if models are required
+```
+
+Create any needed folders (e.g. `uploads/`, `logs/`) before starting Streamlit:
+
+```bash
+streamlit run app.py
+```

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -14,8 +14,15 @@ try:
 except ImportError:
     pass
 
+# Allgemeine Umgebungsvariablen
+STREAMLIT_ENV = os.getenv("STREAMLIT_ENV", "development")
+LANGUAGE = os.getenv("LANGUAGE", "en")
+MODEL_PROVIDER = os.getenv("MODEL_PROVIDER", "openai")
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-4o")
+VECTOR_STORE_PATH = os.getenv("VECTOR_STORE_PATH", "./vector_store")
+
 # OpenAI Modell für ChatCompletion (mit Function Calling)
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4-0613")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)
 # Lokales LLM Modell (für LocalLLMClient)
 LOCAL_MODEL = os.getenv("LOCAL_MODEL", "llama3.2-3b")
 # Flag: Lokalen Modus verwenden (1/0 in Umgebungsvariable oder Boolean in secrets)


### PR DESCRIPTION
## Summary
- document environment variables, secrets and setup instructions in `AGENTS.md`
- improve project README with same guidance
- ignore `secrets.toml` in git
- expose new env vars in `src/config/config.py`

## Testing
- `pytest -q` *(no tests found)*
- `flake8` *(fails: numerous style errors)*
- `mypy src --explicit-package-bases` *(fails: multiple typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ab86490608320a0d9b7c0b26d0335