### PR TITLE
Add missing libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ beautifulsoup4
 tenacity
 pydantic
 graphviz>=0.20
+langchain
+pdfminer.six
+python-dotenv


### PR DESCRIPTION
## Summary
- include langchain, pdfminer.six and python-dotenv in requirements

## Testing
- `pip install -r requirements.txt`
- `pip check`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b0b97b8608320ab51b89e9ff624f0