### PR TITLE
Fix scraping tool decorator

### DIFF
--- a/src/tools/scraping_tools.py
+++ b/src/tools/scraping_tools.py
@@ -1,8 +1,18 @@
-from langchain.tools import tool
+# Optional decorator (works even without tool_registry)
+try:
+    from src.utils.tool_registry import tool
+except (ImportError, ModuleNotFoundError):  # Fallback decorator
+    def tool(_func=None, **_kwargs):  # type: ignore
+        def decorator(func):
+            return func
+        return decorator if _func is None else decorator(_func)
+
 
 @tool(
     name="scrape_company_site",
-    description="Fetches <title> and meta description from a company homepage.",
+    description=(
+        "Fetches <title> and meta description from a company homepage."
+    ),
     parameters={
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- import `tool` from `src.utils.tool_registry` in `scraping_tools`
- fall back to a no-op decorator when `tool_registry` isn't available

## Testing
- `flake8 src/tools/scraping_tools.py`
- `python -m py_compile src/tools/scraping_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_684b0e96a1148320a566c4039def3924