### PR TITLE
Fix llm_utils import path

### DIFF
--- a/src/logic/processors.py
+++ b/src/logic/processors.py
@@ -7,7 +7,13 @@ from typing import Any
 import logging
 
 from src.logic.trigger_engine import TriggerEngine
-from src.llm_utils import call_with_retry, USE_LOCAL_MODEL, local_client, openai
+# Update import path to reflect new module location under utils
+from src.utils.llm_utils import (
+    call_with_retry,
+    USE_LOCAL_MODEL,
+    local_client,
+    openai,
+)
 
 # Use a fast model for suggestions
 _SUGGESTION_MODEL = "gpt-3.5-turbo"


### PR DESCRIPTION
## Summary
- update processors module to use `src.utils.llm_utils`

## Testing
- `python -m py_compile src/logic/processors.py`

------
https://chatgpt.com/codex/tasks/task_e_684b0e9aa8b48320aa58376136aab597