### PR TITLE
Add text cleanup module

### DIFF
--- a/src/tools/file_tools.py
+++ b/src/tools/file_tools.py
@@ -31,6 +31,8 @@ from typing import Literal
 import fitz  # PyMuPDF
 from docx import Document
 
+from src.utils.text_cleanup import clean_text
+
 # Optionaler Decorator (funktioniert auch ohne tool_registry)
 try:
     from src.utils.tool_registry import tool
@@ -87,15 +89,6 @@ def _extract_text_zip_plain(data: bytes) -> str | None:
     return None
 
 
-def _clean_text(text: str) -> str:
-    """Normiert Leerzeichen, Zeilenumbrüche und entfernt Steuerzeichen."""
-    text = text.replace("\r\n", "\n").replace("\r", "\n")
-    text = re.sub(r"[ \t]+", " ", text)                # Mehrfach-Spaces
-    text = re.sub(r"\n{3,}", "\n\n", text)              # >2 Zeilenumbrüche
-    text = re.sub(r"[^\x09\x0A\x0D\x20-\x7E\u00A0-\uFFFF]+", "", text)  # non-printables
-    return text.strip()
-
-
 # --- öffentliches Tool -------------------------------------------------------
 
 @tool(
@@ -144,7 +137,7 @@ def extract_text_from_file(
             text = file_content.decode("utf-8", errors="ignore")
             if not text.strip():  # Fallback Latin-1
                 text = file_content.decode("latin-1", errors="ignore")
-        return _clean_text(text)
+        return clean_text(text)
     except Exception as err:
         logger.error("extract_text_from_file() failed: %s", err, exc_info=True)
         return ""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,1 +1,2 @@
 
+from .text_cleanup import clean_text

--- a/src/utils/text_cleanup.py
+++ b/src/utils/text_cleanup.py
@@ -1,0 +1,31 @@
+"""Utility functions to sanitize text data used across the app."""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["clean_text"]
+
+
+def clean_text(text: str) -> str:
+    """Normalize whitespace and remove control characters from text.
+
+    Parameters
+    ----------
+    text: str
+        Raw text which may contain irregular line breaks or unwanted
+        control characters.
+
+    Returns
+    -------
+    str
+        Cleaned text with at most two consecutive line breaks and
+        without control characters.
+    """
+    if not isinstance(text, str):
+        text = str(text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = re.sub(r"[^\x09\x0A\x0D\x20-\x7E\u00A0-\uFFFF]+", "", text)
+    return text.strip()


### PR DESCRIPTION
## Summary
- provide `src.utils.text_cleanup` with a `clean_text` helper
- re-export `clean_text` from `src.utils`
- remove obsolete `_clean_text` in file_tools

## Testing
- `flake8 src/tools/file_tools.py src/utils/text_cleanup.py`
- `python -m py_compile pages/wizard.py src/utils/text_cleanup.py src/tools/file_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_684b1326b1588320b3ba248a9e4143ff