### PR TITLE
Fix OpenAI exception references

### DIFF
--- a/src/processors/salary.py
+++ b/src/processors/salary.py
@@ -32,10 +32,10 @@ def update_salary_range(state: dict[str, Any]) -> None:
             max_tokens=40,
         )
         result = response.choices[0].message.content.strip()
-    except openai.error.APIConnectionError as e:
+    except openai.APIConnectionError as e:
         logging.error(f"Verbindung zum OpenAI-API fehlgeschlagen: {e}")
         return
-    except openai.error.RateLimitError as e:
+    except openai.RateLimitError as e:
         logging.error(f"OpenAI Rate-Limit überschritten: {e}")
         return
     except Exception as e:

--- a/src/utils/llm_utils.py
+++ b/src/utils/llm_utils.py
@@ -72,8 +72,19 @@ def get_role_skills(job_title: str, num_skills: int = 15) -> List[str]:
     return skills_list
 
 # Wrapper-Funktion mit automatischen Wiederholungen für OpenAI-Aufrufe
-@retry(reraise=True, stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=4),
-       retry=retry_if_exception_type((openai.error.APIConnectionError, openai.error.Timeout, openai.error.RateLimitError, openai.error.APIError)))
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(min=1, max=4),
+    retry=retry_if_exception_type(
+        (
+            openai.APIConnectionError,
+            openai.APITimeoutError,
+            openai.RateLimitError,
+            openai.APIError,
+        )
+    ),
+)
 def _call_with_retry(func, *args, **kwargs):
     return func(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
- fix calls to OpenAI errors after API update

## Testing
- `flake8 src/utils/llm_utils.py src/processors/salary.py | head`
- `python -m py_compile src/processors/salary.py src/utils/llm_utils.py`
- `streamlit run app.py --server.headless true` *(fails: Did not auto detect external IP)*

------
https://chatgpt.com/codex/tasks/task_e_684b2811c0f08320b75808bf5d784953