### PR TITLE
Remove duplicate wizard page

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from pages import wizard
+import wizard
 import base64
 
 # Set up page configuration (title, icon, layout, etc.)

--- a/wizard.py
+++ b/wizard.py
@@ -631,5 +631,3 @@ def _nav(step: int):
         st.button("Zurück" if lang == "Deutsch" else "Back",
                   on_click=lambda: st.session_state.update({"wizard_step": step - 1}), key=f"back_{step}")
 
-# Wizard UI ausführen
-run_wizard()


### PR DESCRIPTION
## Summary
- avoid duplicate sidebar entry by moving `wizard.py` out of the `pages` folder
- update main app import

## Testing
- `python -m py_compile app.py wizard.py pages/2_🏠_Advantages.py pages/3_💡_Tech_Overview.py src/state/session_state.py`
- `flake8 wizard.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b361c0c0c8320bd6f980f7cf6c8ac