### PR TITLE
Fix API key override in OpenAI model

### DIFF
--- a/models/openai_model.py
+++ b/models/openai_model.py
@@ -5,9 +5,13 @@ import openai
 class OpenAIModel:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
-        openai.api_key = os.getenv("OPENAI_API_KEY")
+        key_from_env = os.getenv("OPENAI_API_KEY")
+        if key_from_env:
+            openai.api_key = key_from_env
         if not openai.api_key:
-            self.logger.warning("OPENAI_API_KEY fehlt – OpenAI‑Aufrufe schlagen fehl.")
+            self.logger.warning(
+                "OPENAI_API_KEY fehlt – OpenAI-Aufrufe schlagen fehl."
+            )
 
     def generate(self, prompt: str, temperature: float = 0.2) -> str:
         if not openai.api_key:


### PR DESCRIPTION
## Summary
- avoid clearing existing API key when `OpenAIModel` is initialized

## Testing
- `flake8`
- `python -m py_compile $(git ls-files -z '*.py' | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_684b3a47c2348320a7c44d85079c313e