### PR TITLE
Fix project imports after folder rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ pip install -r requirements.txt
 Create any needed folders (e.g. `uploads/`, `logs/`) before starting Streamlit:
 
 ```bash
-streamlit run vacalyser/app.py
+streamlit run app.py
 ```
 
 ## Project Structure
 
 ```
-vacalyser/
+./
 ├── app.py
 ├── pages/
 ├── components/

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
-import streamlit as st
-from vacalyser.components import wizard
 import base64
+import streamlit as st
+
+from components import wizard
 
 # Set up page configuration (title, icon, layout, etc.)
 st.set_page_config(
@@ -21,7 +22,7 @@ def _set_background(path: str) -> None:
     st.markdown(css, unsafe_allow_html=True)
 
 
-_set_background("../images/AdobeStock_506577005.jpeg")
+_set_background("images/AdobeStock_506577005.jpeg")
 
 # App-wide language selection (German or English)
 if "language" not in st.session_state:

--- a/logic/file_tools.py
+++ b/logic/file_tools.py
@@ -32,11 +32,11 @@ from typing import Literal
 import fitz  # PyMuPDF
 from docx import Document
 
-from vacalyser.utils.text_cleanup import clean_text
+from utils.text_cleanup import clean_text
 
 # Optionaler Decorator (funktioniert auch ohne tool_registry)
 try:
-    from vacalyser.utils.tool_registry import tool
+    from utils.tool_registry import tool
 except (ImportError, ModuleNotFoundError):  # Fallback-Decorator
 
     def tool(_func=None, **_kwargs):  # type: ignore

--- a/logic/processors.py
+++ b/logic/processors.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from typing import Any, cast
 import logging
 
-from vacalyser.logic.trigger_engine import TriggerEngine
-from vacalyser.utils.llm_utils import call_with_retry, openai  # type: ignore
+from logic.trigger_engine import TriggerEngine
+from utils.llm_utils import call_with_retry, openai  # type: ignore
 
 openai = cast(Any, openai)
 

--- a/logic/trigger_engine.py
+++ b/logic/trigger_engine.py
@@ -65,7 +65,7 @@ def build_default_graph(engine: TriggerEngine) -> None:
     """Befüllt die TriggerEngine mit dem Abhängigkeitsgraphen und registriert die Verarbeitungsfunktionen."""
     engine.register_dependencies(_DEPENDENCY_PAIRS)
     # Importiere Verarbeitungsfunktionen
-    from vacalyser.logic.processors import (
+    from logic.processors import (
         update_salary_range,
         update_publication_channels,
         update_task_list,

--- a/services/scraping_tools.py
+++ b/services/scraping_tools.py
@@ -1,6 +1,6 @@
 # Optional decorator (works even without tool_registry)
 try:
-    from vacalyser.utils.tool_registry import tool
+    from utils.tool_registry import tool
 except (ImportError, ModuleNotFoundError):  # Fallback decorator
 
     def tool(_func=None, **_kwargs):  # type: ignore

--- a/services/vacancy_agent.py
+++ b/services/vacancy_agent.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, cast
 
 import openai  # type: ignore
-from vacalyser.utils import config
+from utils import config
 
 openai = cast(Any, openai)
 
@@ -105,8 +105,8 @@ def auto_fill_job_spec(
         except Exception:
             text_length = 0
         if text_length > 100_000:  # ~100 KB
-            from vacalyser.logic.file_tools import extract_text_from_file
-            from vacalyser.utils.summarize import summarize_text
+            from logic.file_tools import extract_text_from_file
+            from utils.summarize import summarize_text
 
             extracted_text = extract_text_from_file(file_bytes, file_name)
             if isinstance(extracted_text, str) and len(extracted_text) > 5000:
@@ -148,7 +148,7 @@ def auto_fill_job_spec(
         func_result = ""
         try:
             if func_name == "scrape_company_site":
-                from vacalyser.services.scraping_tools import scrape_company_site
+                from services.scraping_tools import scrape_company_site
 
                 result_data = scrape_company_site(**func_args)
                 if isinstance(result_data, dict):
@@ -160,7 +160,7 @@ def auto_fill_job_spec(
                 else:
                     func_result = str(result_data)
             elif func_name == "extract_text_from_file":
-                from vacalyser.logic.file_tools import extract_text_from_file
+                from logic.file_tools import extract_text_from_file
                 import base64
 
                 file_content_str = func_args.get("file_content", "")
@@ -204,7 +204,7 @@ def auto_fill_job_spec(
         return {}
     # JSON-String in Pydantic-Modell JobSpec validieren und parsen
     try:
-        from vacalyser.models.job_models import JobSpec
+        from models.job_models import JobSpec
 
         job_spec = JobSpec.model_validate_json(content_str)
     except Exception as e:

--- a/state/session_state.py
+++ b/state/session_state.py
@@ -1,7 +1,8 @@
 # session_state.py
 
 import streamlit as st
-from vacalyser.utils import keys
+
+from utils import keys
 
 
 def initialize_session_state() -> None:

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -1,13 +1,14 @@
 import io
+
 import sys
 from pathlib import Path
 
 import fitz
 from docx import Document
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from vacalyser.logic.file_tools import extract_text_from_file
+from logic.file_tools import extract_text_from_file
 
 
 def _make_pdf_bytes(text: str) -> bytes:

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -12,8 +12,8 @@ from tenacity import (
 )
 
 # Vacancy Agent und Konfiguration importieren
-from vacalyser.services import vacancy_agent
-from vacalyser.utils import config
+from services import vacancy_agent
+from utils import config
 
 openai = cast(Any, openai)
 

--- a/utils/summarize.py
+++ b/utils/summarize.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, cast
 import openai  # type: ignore
 from .llm_utils import call_with_retry
-from vacalyser.utils import config
+from utils import config
 
 openai = cast(Any, openai)
 


### PR DESCRIPTION
## Summary
- update all imports to work without `vacalyser` package
- fix README paths and project structure
- adjust background image path in `app.py`
- repair `tests/test_file_tools.py` to set PYTHONPATH

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c767aa01c83208453bc9aa686a0ee