### PR TITLE
Fix missing faiss dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vacalyser
 ## Setup
 
-Install dependencies before running the app:
+Install dependencies before running the app (includes `faiss-cpu` for the vector store):
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ graphviz>=0.20
 langchain
 pdfminer.six
 python-dotenv
+faiss-cpu
 streamlit-sortables


### PR DESCRIPTION
## Summary
- document that `faiss-cpu` is installed
- add `faiss-cpu` to requirements

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb0840ef883209edc8926fa975f72