### PR TITLE
feat: add retry logic for openai calls

### DIFF
--- a/services/vacancy_agent.py
+++ b/services/vacancy_agent.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, cast
 
 import openai  # type: ignore
 from utils import config
+import utils.llm_utils as llm_utils
 
 openai = cast(Any, openai)
 
@@ -125,7 +126,8 @@ def auto_fill_job_spec(
         {"role": "user", "content": user_message},
     ]
     try:
-        response = openai.ChatCompletion.create(  # type: ignore[attr-defined]
+        response = llm_utils.call_with_retry(
+            openai.ChatCompletion.create,  # type: ignore[attr-defined]
             model=config.OPENAI_MODEL,
             messages=messages,
             functions=FUNCTIONS,
@@ -177,7 +179,8 @@ def auto_fill_job_spec(
         # Ergebnis der Funktion als Assistant-Antwort hinzufügen und zweiten API-Call durchführen
         messages.append({"role": "function", "name": func_name, "content": func_result})
         try:
-            second_response = openai.ChatCompletion.create(  # type: ignore[attr-defined]
+            second_response = llm_utils.call_with_retry(
+                openai.ChatCompletion.create,  # type: ignore[attr-defined]
                 model=config.OPENAI_MODEL,
                 messages=messages,
                 functions=FUNCTIONS,

--- a/services/vector_search.py
+++ b/services/vector_search.py
@@ -9,6 +9,7 @@ import numpy as np
 import openai  # type: ignore
 
 from utils import config
+from utils.llm_utils import call_with_retry
 
 
 class VectorStore:
@@ -37,7 +38,8 @@ class VectorStore:
 
     def _embed(self, texts: List[str]) -> np.ndarray:
         """Embed texts via OpenAI embeddings."""
-        result = openai.Embedding.create(  # type: ignore[attr-defined]
+        result = call_with_retry(
+            openai.Embedding.create,  # type: ignore[attr-defined]
             model="text-embedding-3-small",
             input=texts,
         )

--- a/tests/test_vacancy_agent.py
+++ b/tests/test_vacancy_agent.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import streamlit as st
+import openai
+
+
+class DummyMessage:
+    def __init__(self, content, function_call=None):
+        self.content = content
+        self.function_call = function_call
+
+
+class DummyChoice:
+    def __init__(self, message):
+        self.message = message
+
+
+class DummyResponse:
+    def __init__(self, message):
+        self.choices = [DummyChoice(message)]
+
+
+def test_auto_fill_job_spec_uses_retry(monkeypatch):
+    def fake_call_with_retry(func, *args, **kwargs):
+        assert func is openai.ChatCompletion.create
+        return DummyResponse(DummyMessage('{"job_title": "Engineer"}'))
+
+    monkeypatch.setattr(st, "secrets", {})
+    from services import vacancy_agent as vac
+
+    monkeypatch.setattr(vac.llm_utils, "call_with_retry", fake_call_with_retry)
+    auto_fill_job_spec = vac.auto_fill_job_spec
+
+    result = auto_fill_job_spec(file_bytes=b"dummy", file_name="test.txt")
+
+    assert result.get("job_title") == "Engineer"

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import streamlit as st
+import openai
+
+
+def test_vector_search_embed_uses_retry(monkeypatch):
+    called = {}
+
+    def fake_call_with_retry(func, *args, **kwargs):
+        called["func"] = func
+        return {"data": [{"embedding": [0.0] * 1536}]}
+
+    monkeypatch.setattr(st, "secrets", {})
+    from services import vector_search as vs
+
+    monkeypatch.setattr(vs, "call_with_retry", fake_call_with_retry)
+    VectorStore = vs.VectorStore
+
+    store = VectorStore(path="/tmp/vector_store_test")
+    vecs = store._embed(["test text"])
+
+    assert called["func"] is openai.Embedding.create
+    assert isinstance(vecs, np.ndarray)
+    assert vecs.shape == (1, 1536)


### PR DESCRIPTION
## Summary
- retry ChatCompletion calls via call_with_retry in vacancy_agent
- use call_with_retry for embedding generation
- test wrappers for both modules

## Testing
- `ruff check .`
- `black . --check`
- `mypy ./services ./utils ./components ./logic ./models ./state ./tests ./pages ./app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb5b9aabc832091b933df55957ee4