### PR TITLE
Add tests for VectorStore and job tools

### DIFF
--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -1,0 +1,36 @@
+from models.job_models import JobSpec
+from logic.job_tools import (
+    parse_job_spec,
+    progress_percentage,
+    highlight_keywords,
+)
+from utils.keys import STEP_KEYS
+
+
+def test_parse_job_spec_basic() -> None:
+    text = "Job: Developer\nCompany: ACME\nSalary: 50k"
+    spec = parse_job_spec(text)
+    assert isinstance(spec, JobSpec)
+    assert spec.job_title == "Developer"
+    assert spec.company_name == "ACME"
+    assert spec.salary_range == "50k"
+
+
+def test_parse_job_spec_empty() -> None:
+    spec = parse_job_spec("")
+    assert spec.job_title is None
+    assert spec.company_name is None
+    assert spec.salary_range is None
+
+
+def test_progress_percentage_single_field() -> None:
+    total = sum(len(v) for v in STEP_KEYS.values())
+    state: dict[str, object] = {"job_title": "Dev"}
+    expected = round(1 / total * 100, 1)
+    assert progress_percentage(state) == expected
+
+
+def test_highlight_keywords_case_insensitive() -> None:
+    text = "Python developer needed"
+    result = highlight_keywords(text, ["python"])
+    assert result.startswith("**Python**")

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import faiss
+import numpy as np
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from services.vector_search import VectorStore
+
+
+def test_search_returns_expected_results(tmp_path: Path) -> None:
+    store = VectorStore(path=tmp_path)
+    dim = 1536
+    index = faiss.IndexFlatL2(dim)
+    embeddings = np.zeros((3, dim), dtype="float32")
+    embeddings[0, 0] = 1.0
+    embeddings[1, 1] = 1.0
+    embeddings[2, 2] = 1.0
+    index.add(embeddings)
+
+    store.index = index
+    store.texts = ["alpha", "beta", "gamma"]
+
+    query_vec = np.zeros((1, dim), dtype="float32")
+    query_vec[0, 0] = 1.0
+
+    with patch.object(store, "_embed", return_value=query_vec):
+        results = store.search("alpha", k=2)
+
+    assert results
+    assert results[0] == "alpha"
+    assert len(results) == 2
+
+
+def test_search_empty_index_returns_empty(tmp_path: Path) -> None:
+    store = VectorStore(path=tmp_path)
+    with patch.object(store, "_embed") as embed_mock:
+        results = store.search("anything")
+    assert results == []
+    embed_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- cover `VectorStore.search` with dummy FAISS vectors
- add unit tests for job_tools helpers

## Testing
- `ruff check`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb5ce6dfc8320be233dd7b6720472