### PR TITLE
feat: add company web scraper to discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ You can also set the variables via a `.env` file during local development.
 └── tests/
 ```
 
+### Features
+
+- Start discovery page can scrape basic company information when a website URL is provided.
+
 ## ESCO API Prompt Templates
 
 A collection of ready-made prompts for querying the ESCO API is available in [docs/esco_api_prompts.md](docs/esco_api_prompts.md).

--- a/components/wizard.py
+++ b/components/wizard.py
@@ -235,6 +235,16 @@ def start_discovery_page():
         )
         if input_url:
             st.session_state["input_url"] = input_url
+        company_url = st.text_input(
+            (
+                "🌐 Unternehmenswebseite (optional)"
+                if lang == "Deutsch"
+                else "🌐 Company Website (optional)"
+            ),
+            value=st.session_state.get("company_website", ""),
+        )
+        if company_url:
+            st.session_state["company_website"] = company_url
     with col2:
         uploaded_file = st.file_uploader(btn_upload, type=["pdf", "docx", "txt"])
         if uploaded_file is not None:
@@ -270,6 +280,23 @@ def start_discovery_page():
                 else "⚠️ Please provide a valid URL or upload a file."
             )
             return
+        if st.session_state.get("company_website"):
+            info = scrape_company_site(st.session_state["company_website"])
+            st.session_state["company_site_title"] = info.get("title", "")
+            st.session_state["company_site_description"] = info.get("description", "")
+            if info.get("title") or info.get("description"):
+                with st.expander(
+                    (
+                        "Gefundene Unternehmensinfos"
+                        if lang == "Deutsch"
+                        else "Fetched Company Info"
+                    ),
+                    expanded=False,
+                ):
+                    if info.get("title"):
+                        st.write(f"**Title:** {info['title']}")
+                    if info.get("description"):
+                        st.write(f"**Description:** {info['description']}")
         if not config.OPENAI_API_KEY:
             st.error(
                 "❌ KI-Funktionen nicht verfügbar. Bitte OPENAI_API_KEY konfigurieren."

--- a/tests/test_scraping_tools.py
+++ b/tests/test_scraping_tools.py
@@ -1,0 +1,16 @@
+from unittest.mock import Mock, patch
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from services.scraping_tools import scrape_company_site
+
+
+def test_scrape_company_site_parses_title_and_description() -> None:
+    html = (
+        "<html><head><title>MyCo</title>"
+        "<meta name='description' content='Great services'></head></html>"
+    )
+    mock_resp = Mock(status_code=200, text=html)
+    with patch("requests.get", return_value=mock_resp):
+        result = scrape_company_site("http://example.com")
+    assert result == {"title": "MyCo", "description": "Great services"}


### PR DESCRIPTION
## Summary
- let users specify a company website in `start_discovery_page`
- scrape title and meta description from the site and show them
- test web scraping with a mocked request
- document the new feature in README

## Testing
- `ruff check .`
- `black --check components/wizard.py tests/test_scraping_tools.py`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d4b92279483208649baf86451a582