### PR TITLE
feat: add helper utilities and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ You can also set the variables via a `.env` file during local development.
 ### Features
 
 - Start discovery page can scrape basic company information when a website URL is provided.
+- Utility helpers now include:
+  - `build_boolean_query` to create candidate search strings.
+  - `generate_interview_questions` for quick interview prep.
+  - `summarize_job_ad` to get short ad summaries.
 
 ## ESCO API Prompt Templates
 

--- a/logic/job_tools.py
+++ b/logic/job_tools.py
@@ -52,3 +52,42 @@ def highlight_keywords(text: str, keywords: List[str]) -> str:
         return text
     pattern = re.compile(r"(" + "|".join(map(re.escape, keywords)) + r")", re.I)
     return pattern.sub(r"**\1**", text)
+
+
+def build_boolean_query(job_title: str, skills: List[str]) -> str:
+    """Return a simple boolean search string for external candidate platforms."""
+    title_part = f'"{normalize_job_title(job_title)}"' if job_title else ""
+    skill_terms = [f'"{s}"' for s in skills if s]
+    query_parts = [p for p in [title_part, " OR ".join(skill_terms)] if p]
+    if len(query_parts) == 1:
+        return query_parts[0]
+    return f"{query_parts[0]} AND ({query_parts[1]})"
+
+
+def generate_interview_questions(
+    responsibilities: str, num_questions: int = 5
+) -> List[str]:
+    """Generate basic interview questions from given responsibilities text."""
+    if not responsibilities:
+        return []
+    lines = [
+        ln.strip(" -*\u2022") for ln in responsibilities.splitlines() if ln.strip()
+    ]
+    if not lines:
+        lines = [r.strip() for r in re.split(r"[.;]", responsibilities) if r.strip()]
+    questions = []
+    for item in lines[:num_questions]:
+        questions.append(f"Can you describe your experience with {item}?")
+    while len(questions) < num_questions:
+        questions.append("Tell us more about your relevant experience.")
+    return questions
+
+
+def summarize_job_ad(text: str, max_words: int = 50) -> str:
+    """Create a short summary from a job advertisement text."""
+    if not text:
+        return ""
+    words = text.split()
+    if len(words) > max_words:
+        return " ".join(words[:max_words]) + "..."
+    return text

--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -3,6 +3,9 @@ from logic.job_tools import (
     parse_job_spec,
     progress_percentage,
     highlight_keywords,
+    build_boolean_query,
+    generate_interview_questions,
+    summarize_job_ad,
 )
 from utils.keys import STEP_KEYS
 
@@ -34,3 +37,23 @@ def test_highlight_keywords_case_insensitive() -> None:
     text = "Python developer needed"
     result = highlight_keywords(text, ["python"])
     assert result.startswith("**Python**")
+
+
+def test_build_boolean_query() -> None:
+    query = build_boolean_query("Data Scientist", ["Python", "SQL"])
+    assert '"Data Scientist"' in query
+    assert "Python" in query and "SQL" in query
+
+
+def test_generate_interview_questions() -> None:
+    tasks = "Develop models\nAnalyze data"
+    questions = generate_interview_questions(tasks, num_questions=2)
+    assert len(questions) == 2
+    assert all("?" in q for q in questions)
+
+
+def test_summarize_job_ad() -> None:
+    text = "word " * 100
+    summary = summarize_job_ad(text, max_words=5)
+    assert summary.endswith("...")
+    assert len(summary.split()) <= 6


### PR DESCRIPTION
## Summary
- add new utility functions for boolean query building, interview questions, and ad summaries
- document new helpers in README
- test new utilities

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5e10da748320a58faeeac2744f6b