### PR TITLE
Add vacancy agent JSON repair tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can also set the variables via a `.env` file during local development.
 ### Features
 
 - Start discovery page can scrape basic company information when a website URL is provided.
+- Vacancy agent includes automatic JSON repair to ensure outputs match the JobSpec schema (tested in `tests/test_vacancy_agent.py`).
 
 ## ESCO API Prompt Templates
 

--- a/tests/test_vacancy_agent.py
+++ b/tests/test_vacancy_agent.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from models.job_models import JobSpec
+from services.vacancy_agent import fix_json_output
+
+
+def test_fix_json_output_returns_same_when_json_valid() -> None:
+    spec = JobSpec(job_title="Dev")
+    raw = spec.model_dump_json()
+    result = fix_json_output(raw)
+    assert result == spec.model_dump()
+
+
+def test_fix_json_output_repairs_malformed_json() -> None:
+    malformed = '{"job_title": "Engineer", "company_name": "ACME",}'
+    fixed_spec = JobSpec(job_title="Engineer", company_name="ACME")
+    completion = fixed_spec.model_dump_json()
+    fake_resp = Mock()
+    fake_resp.choices = [Mock(message=Mock(content=completion))]
+
+    with patch(
+        "services.vacancy_agent.openai.chat.completions.create",
+        return_value=fake_resp,
+    ) as create_mock:
+        result = fix_json_output(malformed)
+
+    create_mock.assert_called_once()
+    assert result == fixed_spec.model_dump()


### PR DESCRIPTION
## Summary
- add unit tests for `fix_json_output`
- document JSON repair feature in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d5e4a69888320adc7c9f76fcbcf61