### PR TITLE
Add package install and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install -e .
+      - run: pip install ruff black mypy pytest
+      - run: ruff check .
+      - run: black --check .
+      - run: mypy .
+      - run: pytest -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Before running the app locally:
 
 ```bash
 pip install -r requirements.txt
+pip install -e .
 ```
 
 Ensure directories such as `uploads/` and `logs/` exist. Then start the app with `streamlit run app.py`.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ You can also place these values in a `.env` file and load them in Python via
 ## ESCO API Prompt Templates
 
 A collection of ready-made prompts for querying the ESCO API is available in [docs/esco_api_prompts.md](docs/esco_api_prompts.md).
+
+## Testing
+
+The CI pipeline installs the project in editable mode so that imports work consistently:
+
+```bash
+pip install -e .
+pytest
+```
+
+Run these commands locally to mirror the GitHub Actions setup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vacalyser"
+version = "0.1.0"
+description = "Vacalyser workflow demo"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+
+[tool.setuptools.packages.find]
+exclude = ["tests*", "docs*", "images*"]


### PR DESCRIPTION
## Summary
- package code as `vacalyser`
- run `pip install -e .` in CI before tests
- document editable install in README and contributor guide

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d698d7f4883208fa596d0a0e21a05