### PR TITLE
fix: handle none or empty index in search

### DIFF
--- a/services/vector_search.py
+++ b/services/vector_search.py
@@ -77,7 +77,9 @@ class VectorStore:
         Returns:
             List of stored texts ranked by similarity.
         """
-        if not query or self.index is None or self.index.ntotal == 0:
+        if self.index is None or self.index.ntotal == 0:
+            return []
+        if not query:
             return []
         q_emb = self._embed([query])
         dists, idxs = self.index.search(q_emb, k)

--- a/tests/test_vector_search.py
+++ b/tests/test_vector_search.py
@@ -41,3 +41,12 @@ def test_search_empty_index_returns_empty(tmp_path: Path) -> None:
         results = store.search("anything")
     assert results == []
     embed_mock.assert_not_called()
+
+
+def test_search_none_index_returns_empty(tmp_path: Path) -> None:
+    store = VectorStore(path=tmp_path)
+    store.index = None
+    with patch.object(store, "_embed") as embed_mock:
+        results = store.search("anything")
+    assert results == []
+    embed_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- guard VectorStore.search when index is None or empty
- test empty index search returns empty list
- test None index search also returns empty list

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d699b7c548320966126e83eef4174