### PR TITLE
fix: enhance pdf auto-fill

### DIFF
--- a/tests/test_wizard_utils.py
+++ b/tests/test_wizard_utils.py
@@ -1,0 +1,16 @@
+from components.wizard import match_and_store_keys
+
+
+def test_match_and_store_keys_extracts_values() -> None:
+    text = "Company Name: ACME\nCity: Berlin"
+    state: dict[str, str | None] = {"company_name": None, "city": None}
+    match_and_store_keys(text, state)
+    assert state["company_name"] == "ACME"
+    assert state["city"] == "Berlin"
+
+
+def test_match_and_store_keys_does_not_override_existing() -> None:
+    text = "City: Berlin"
+    state = {"city": "Hamburg"}
+    match_and_store_keys(text, state)
+    assert state["city"] == "Hamburg"


### PR DESCRIPTION
## Summary
- improve match_and_store_keys to avoid overwriting existing fields
- run match_and_store_keys after AI extraction to capture missing labels
- add unit tests for the helper

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6cef44588320bdce400ab50d0ec8