### PR TITLE
feat: add skill suggestion button

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can also place these values in a `.env` file and load them in Python via
   - `build_boolean_query` to create candidate search strings.
   - `generate_interview_questions` for quick interview prep.
   - `summarize_job_ad` to get short ad summaries.
+  - Step 5 now offers a "Suggest skills" button generating technical and soft skill keywords.
 
 ## ESCO API Prompt Templates
 

--- a/components/wizard.py
+++ b/components/wizard.py
@@ -682,6 +682,74 @@ def render_step5_static():
     )
     display_step_summary(5)
 
+    if st.button("Skillvorschläge" if lang == "Deutsch" else "Suggest skills"):
+        from logic.processors import suggest_additional_skills
+
+        st.session_state["skill_suggestions"] = suggest_additional_skills(
+            st.session_state.get("job_title", ""),
+            st.session_state.get("task_list", ""),
+            st.session_state.get("job_level", ""),
+            st.session_state.get("parsed_data_raw", ""),
+        )
+
+    suggestions = st.session_state.get("skill_suggestions")
+    if suggestions:
+        st.subheader(
+            "Vorgeschlagene Skills" if lang == "Deutsch" else "Suggested Skills"
+        )
+        tech_col, soft_col = st.columns(2)
+
+        with tech_col:
+            st.markdown("**Technical Skills**")
+            st.multiselect(
+                "Must-Have",
+                suggestions.get("technical", []),
+                key="tech_must_select",
+            )
+            st.multiselect(
+                "Nice-to-Have",
+                suggestions.get("technical", []),
+                key="tech_nice_select",
+            )
+
+        with soft_col:
+            st.markdown("**Soft Skills**")
+            st.multiselect(
+                "Must-Have",
+                suggestions.get("soft", []),
+                key="soft_must_select",
+            )
+            st.multiselect(
+                "Nice-to-Have",
+                suggestions.get("soft", []),
+                key="soft_nice_select",
+            )
+
+        def _apply_suggestions() -> None:
+            mh = st.session_state.setdefault("must_have_skills_list", [])
+            nh = st.session_state.setdefault("nice_to_have_skills_list", [])
+            for s in st.session_state.get("tech_must_select", []):
+                if s not in mh:
+                    mh.append(s)
+            for s in st.session_state.get("soft_must_select", []):
+                if s not in mh:
+                    mh.append(s)
+            for s in st.session_state.get("tech_nice_select", []):
+                if s not in nh:
+                    nh.append(s)
+            for s in st.session_state.get("soft_nice_select", []):
+                if s not in nh:
+                    nh.append(s)
+            st.session_state["tech_must_select"] = []
+            st.session_state["soft_must_select"] = []
+            st.session_state["tech_nice_select"] = []
+            st.session_state["soft_nice_select"] = []
+
+        st.button(
+            "Auswahl übernehmen" if lang == "Deutsch" else "Add selected",
+            on_click=_apply_suggestions,
+        )
+
     st.write(
         "Ziehe deine eingegebenen Fähigkeiten einfach zwischen die Spalten"
         if lang == "Deutsch"

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from logic.processors import suggest_additional_skills
+
+
+def test_suggest_additional_skills_parses_json() -> None:
+    response_data = {"technical": ["Python", "SQL"], "soft": ["Communication"]}
+    fake_resp = Mock()
+    fake_resp.choices = [Mock(message=Mock(content=json.dumps(response_data)))]
+
+    with patch(
+        "logic.processors.openai.chat.completions.create",
+        return_value=fake_resp,
+    ) as create_mock:
+        result = suggest_additional_skills(
+            "Data Scientist",
+            "Analyze data",
+            "Senior",
+            "Some job ad text",
+            num_skills=2,
+        )
+    create_mock.assert_called_once()
+    assert result == {
+        "technical": ["Python", "SQL"],
+        "soft": ["Communication"],
+    }


### PR DESCRIPTION
## Summary
- offer button to suggest skills for step 5 and UI to select them
- generate additional skills via `suggest_additional_skills`
- test skill suggestion helper
- mention feature in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d85c94e188320a922ff8c42cef76d