### PR TITLE
feat: suggest additional skills in wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ OpenAI's GPT models.
 
 - **AI-driven extraction** of existing job descriptions or URLs.
 - **Interactive eight-step wizard** available in English and German.
+- **Skill suggestions** button in step 5 recommends additional technical and
+  soft skills not found in the job ad.
 - **Trigger Engine** built on a dependency graph that auto-updates related
   fields as you change inputs.
 - **Prompt library and `@tool` functions** for text extraction and web

--- a/components/wizard.py
+++ b/components/wizard.py
@@ -20,6 +20,7 @@ from logic.job_tools import (
     progress_percentage,
     highlight_keywords,
 )
+from utils.llm_utils import suggest_additional_skills
 from utils import config
 
 # Session State initialisieren (nur beim ersten Aufruf)
@@ -681,6 +682,49 @@ def render_step5_static():
         else "Step 5: Skills & Competencies"
     )
     display_step_summary(5)
+
+    if st.button(
+        "Top-Skills vorschlagen" if lang == "Deutsch" else "Suggest Top Skills"
+    ):
+        suggestions = suggest_additional_skills(
+            st.session_state.get("job_title", ""),
+            st.session_state.get("task_list", ""),
+            st.session_state.get("job_level", ""),
+            st.session_state.get("must_have_skills", "")
+            + "\n"
+            + st.session_state.get("nice_to_have_skills", ""),
+        )
+        st.session_state["suggested_technical"] = suggestions["technical"]
+        st.session_state["suggested_soft"] = suggestions["soft"]
+
+    if st.session_state.get("suggested_technical") or st.session_state.get(
+        "suggested_soft"
+    ):
+        col_a, col_b = st.columns(2)
+        with col_a:
+            selected_tech = st.multiselect(
+                "Technical Skills",
+                options=st.session_state.get("suggested_technical", []),
+                key="select_tech",
+            )
+            if st.button("Zu Muss", key="add_tech"):
+                for skill in selected_tech:
+                    st.session_state.setdefault("must_have_skills_list", []).append(
+                        skill
+                    )
+                st.session_state["select_tech"] = []
+        with col_b:
+            selected_soft = st.multiselect(
+                "Soft Skills",
+                options=st.session_state.get("suggested_soft", []),
+                key="select_soft",
+            )
+            if st.button("Zu Nice", key="add_soft"):
+                for skill in selected_soft:
+                    st.session_state.setdefault("nice_to_have_skills_list", []).append(
+                        skill
+                    )
+                st.session_state["select_soft"] = []
 
     st.write(
         "Ziehe deine eingegebenen Fähigkeiten einfach zwischen die Spalten"

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from utils.llm_utils import suggest_additional_skills
+
+
+def test_suggest_additional_skills_parses_output() -> None:
+    fake_content = "Technical Skills:\n- Python\n- SQL\nSoft Skills:\n- Leadership\n- Communication"
+    fake_resp = Mock()
+    fake_resp.choices = [Mock(message=Mock(content=fake_content))]
+
+    with patch(
+        "utils.llm_utils.openai.chat.completions.create",
+        return_value=fake_resp,
+    ):
+        result = suggest_additional_skills("Engineer")
+
+    assert result["technical"] == ["Python", "SQL"]
+    assert result["soft"] == ["Leadership", "Communication"]


### PR DESCRIPTION
## Summary
- add skill suggestions button in step 5
- implement `suggest_additional_skills` helper
- update README key features
- add tests for the new helper

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_684d8800b418832084f12981028c633b