### PR TITLE
feat: task plan & search utilities

### DIFF
--- a/components/wizard.py
+++ b/components/wizard.py
@@ -671,6 +671,15 @@ def render_step4_static():
             else "e.g. Project management, team coordination"
         ),
     )
+    if st.button("30/60/90-Plan" if lang == "Deutsch" else "30/60/90 Plan"):
+        from logic.job_tools import generate_task_plan
+
+        plan = generate_task_plan(task_list or key_responsibilities)
+        with st.expander("30/60/90 Plan", expanded=True):
+            for label, items in plan.items():
+                st.markdown(f"**{label.replace('_', '/')}**")
+                for it in items:
+                    st.write(f"- {it}")
     return {"task_list": task_list, "key_responsibilities": key_responsibilities}
 
 
@@ -1180,6 +1189,30 @@ def render_step8():
         if lang == "Deutsch"
         else "🎉 All steps completed! Review all inputs and proceed to generate the job description."
     )
+
+    if st.button("Interviewfragen" if lang == "Deutsch" else "Interview Questions"):
+        from logic.job_tools import generate_interview_questions
+
+        questions = generate_interview_questions(
+            st.session_state.get("key_responsibilities", "")
+            or st.session_state.get("task_list", "")
+        )
+        st.session_state["generated_interview_prep"] = "\n".join(questions)
+        with st.expander("Interview Questions", expanded=True):
+            for q in questions:
+                st.write("- " + q)
+
+    if st.button("Boolean Query"):
+        from logic.job_tools import build_boolean_query
+
+        skills = [
+            s.strip()
+            for s in st.session_state.get("must_have_skills", "").split("\n")
+            if s.strip()
+        ]
+        query = build_boolean_query(st.session_state.get("job_title", ""), skills)
+        st.session_state["generated_boolean_query"] = query
+        st.text_area("Search Query", value=query, height=80)
 
 
 def run_wizard():

--- a/logic/job_tools.py
+++ b/logic/job_tools.py
@@ -121,3 +121,28 @@ def summarize_job_ad(text: str, max_words: int = 50) -> str:
     if len(words) > max_words:
         return " ".join(words[:max_words]) + "..."
     return text
+
+
+def generate_task_plan(task_list: str) -> dict[str, list[str]]:
+    """Split tasks into a basic 30/60/90 day plan.
+
+    Args:
+        task_list: Multiline string of role tasks or responsibilities.
+
+    Returns:
+        Dict with ``day_30``, ``day_60`` and ``day_90`` lists.
+    """
+
+    if not task_list:
+        return {"day_30": [], "day_60": [], "day_90": []}
+
+    tasks = [t.strip(" -*\u2022") for t in task_list.splitlines() if t.strip()]
+    if not tasks:
+        return {"day_30": [], "day_60": [], "day_90": []}
+
+    chunk = max(1, len(tasks) // 3)
+    return {
+        "day_30": tasks[:chunk],
+        "day_60": tasks[chunk : 2 * chunk],
+        "day_90": tasks[2 * chunk :],
+    }

--- a/tests/test_job_tools.py
+++ b/tests/test_job_tools.py
@@ -6,6 +6,7 @@ from logic.job_tools import (
     build_boolean_query,
     generate_interview_questions,
     summarize_job_ad,
+    generate_task_plan,
 )
 from utils.keys import STEP_KEYS
 
@@ -57,3 +58,10 @@ def test_summarize_job_ad() -> None:
     summary = summarize_job_ad(text, max_words=5)
     assert summary.endswith("...")
     assert len(summary.split()) <= 6
+
+
+def test_generate_task_plan_splits_list() -> None:
+    tasks = "Task A\nTask B\nTask C\nTask D"
+    plan = generate_task_plan(tasks)
+    assert set(plan.keys()) == {"day_30", "day_60", "day_90"}
+    assert plan["day_30"]


### PR DESCRIPTION
## Summary
- generate simple 30/60/90 day plan from tasks
- offer task plan button in step 4
- add buttons for interview questions and boolean search query in step 8
- cover new helper in unit tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8b48e0b08320a9f5ea2f0e89137a