### PR TITLE
fix: use provided file bytes in analysis

### DIFF
--- a/services/vacancy_agent.py
+++ b/services/vacancy_agent.py
@@ -167,13 +167,23 @@ def auto_fill_job_spec(
                 from logic.file_tools import extract_text_from_file
                 import base64
 
-                file_content_str = func_args.get("file_content", "")
-                filename = func_args.get("filename", "")
-                try:
-                    file_bytes_input = base64.b64decode(file_content_str)
-                except Exception:
-                    file_bytes_input = file_content_str.encode("utf-8", "ignore")
-                func_result = extract_text_from_file(file_bytes_input, filename) or ""
+                # Prefer bytes provided to ``auto_fill_job_spec``
+                file_bytes_input = file_bytes or b""
+                filename_input = file_name or ""
+
+                if not file_bytes_input:
+                    file_content_str = func_args.get("file_content", "")
+                    try:
+                        file_bytes_input = base64.b64decode(file_content_str)
+                    except Exception:
+                        file_bytes_input = file_content_str.encode("utf-8", "ignore")
+
+                if not filename_input:
+                    filename_input = func_args.get("filename", "")
+
+                func_result = (
+                    extract_text_from_file(file_bytes_input, filename_input) or ""
+                )
                 if not isinstance(func_result, str):
                     func_result = str(func_result)
         except Exception as e:

--- a/tests/test_vacancy_agent.py
+++ b/tests/test_vacancy_agent.py
@@ -31,3 +31,34 @@ def test_fix_json_output_repairs_malformed_json() -> None:
 
     create_mock.assert_called_once()
     assert result == fixed_spec.model_dump()
+
+
+def test_auto_fill_uses_file_bytes() -> None:
+    call_obj = Mock()
+    call_obj.name = "extract_text_from_file"
+    call_obj.arguments = "{}"
+    fake_first = Mock()
+    fake_first.choices = [Mock(message=Mock(function_call=call_obj))]
+    fake_second = Mock()
+    fake_second.choices = [Mock(message=Mock(content='{"job_title": "Dev"}'))]
+    responses = [fake_first, fake_second]
+
+    def fake_create(*_args, **_kwargs):
+        return responses.pop(0)
+
+    with (
+        patch(
+            "services.vacancy_agent.openai.chat.completions.create",
+            side_effect=fake_create,
+        ) as create_mock,
+        patch(
+            "logic.file_tools.extract_text_from_file", return_value="job text"
+        ) as extract_mock,
+    ):
+        from services.vacancy_agent import auto_fill_job_spec
+
+        result = auto_fill_job_spec(file_bytes=b"abc", file_name="sample.txt")
+
+    extract_mock.assert_called_once_with(b"abc", "sample.txt")
+    assert result["job_title"] == "Dev"
+    assert create_mock.call_count == 2


### PR DESCRIPTION
## Summary
- ensure `auto_fill_job_spec` always uses provided file bytes
- cover regression with unit test

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684db038ca4c83208221ff2760e54b0b