### PR TITLE
fix: robustly strip json code fences

### DIFF
--- a/services/vacancy_agent.py
+++ b/services/vacancy_agent.py
@@ -211,9 +211,13 @@ def auto_fill_job_spec(
 
     # 'content' sollte nun den JSON-String entsprechend JobSpec enthalten
     content_str = content.strip()
-    if content_str.startswith("```"):
-        # Etwaige Markdown-Formatierung entfernen
-        content_str = content_str.strip("``` \n")
+    if content_str.startswith("```") and content_str.endswith("```"):
+        # remove surrounding code fences and optional language hints
+        content_str = content_str[3:-3].strip()
+        if content_str.lower().startswith("json"):
+            content_str = content_str[4:].strip()
+    elif content_str.startswith("```"):
+        content_str = content_str.strip("` \n")
     if content_str == "":
         return {}
     # JSON-String in Pydantic-Modell JobSpec validieren und parsen


### PR DESCRIPTION
## Summary
- improve JSON cleaning logic in `auto_fill_job_spec`

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684db597c2888320be0cd3ce46919c59