### PR TITLE
Improve text label extraction

### DIFF
--- a/components/wizard.py
+++ b/components/wizard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from datetime import date
 from typing import Any, cast
+import re
 
 import streamlit as st
 import requests  # type: ignore
@@ -146,17 +147,13 @@ def match_and_store_keys(
     for key, label in labels.items():
         if state.get(key):
             continue
-        if label in raw_text:
-            try:
-                value = (
-                    raw_text.split(label, 1)[1]
-                    .split("\n", 1)[0]
-                    .lstrip(": ")
-                    .rstrip(":;,.")
-                    .strip()
-                )
-            except IndexError:
-                continue
+        clean_label = label.rstrip(":")
+        pattern = re.compile(
+            rf"{re.escape(clean_label)}\s*[:\-]?\s*(.+)", re.IGNORECASE
+        )
+        match = pattern.search(raw_text)
+        if match:
+            value = match.group(1).split("\n", 1)[0].strip(" :;,.\t")
             if value:
                 state[key] = value
 

--- a/tests/test_wizard_utils.py
+++ b/tests/test_wizard_utils.py
@@ -1,8 +1,12 @@
-from components.wizard import match_and_store_keys
+from unittest.mock import patch
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from components.wizard import match_and_store_keys
 
 
 def test_match_and_store_keys_extracts_values() -> None:
-    text = "Company Name: ACME\nCity: Berlin"
+    text = "company name - ACME\ncity: Berlin"
     state: dict[str, str | None] = {"company_name": None, "city": None}
     match_and_store_keys(text, state)
     assert state["company_name"] == "ACME"


### PR DESCRIPTION
## Summary
- improve fallback text label matching
- cover new patterns in wizard utils tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dcc409abc8320bc7fdba4959e55f8