### PR TITLE
feat: improve job page text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ OpenAI's GPT models.
 - **Helper utilities** such as `build_boolean_query`,
   `generate_interview_questions` and `summarize_job_ad`.
 - **File and web search helpers** plus image generation for maps and timelines.
+- **Job URL extraction** now uses readability-lxml to fetch the full text of
+  job postings.
 - **Discovery page** can scrape basic company information from a provided URL.
 
 ## Prerequisites
@@ -73,6 +75,8 @@ DATABASE_URL = "postgresql://user:pass@host/db"
 Replace `YOUR_OPENAI_KEY` with your actual key or set the
 `OPENAI_API_KEY` environment variable. Streamlit will read the
 environment variable when the key is not present in `secrets.toml`.
+Without a valid API key the wizard falls back to simple label parsing
+instead of AI-powered extraction.
 
 ## Running the App
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests>=2.32
 streamlit>=1.45
 streamlit-sortables>=0.3
 tenacity>=9.1
+readability-lxml>=0.8

--- a/tests/test_fetch_url_text.py
+++ b/tests/test_fetch_url_text.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock, patch
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from components.wizard import fetch_url_text
+
+
+def test_fetch_url_text_job_html() -> None:
+    html = "<html><head><title>Dev</title></head><body>Join us</body></html>"
+    mock_resp = Mock(status_code=200, text=html, headers={"content-type": "text/html"})
+    doc_inst = Mock()
+    doc_inst.summary.return_value = "<article>Join us</article>"
+    with (
+        patch("components.wizard.requests.get", return_value=mock_resp),
+        patch("components.wizard.Document", return_value=doc_inst),
+    ):
+        text = fetch_url_text("http://example.com/job")
+    assert "Join us" in text


### PR DESCRIPTION
## Summary
- parse full job ad pages via readability-lxml
- add dependency for readability-lxml
- clarify OPENAI key requirement in README
- unit test for fetch_url_text

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_684deef11f8483209ee4952f1507605e