### PR TITLE
Add basic language detection

### DIFF
--- a/components/wizard.py
+++ b/components/wizard.py
@@ -352,13 +352,12 @@ def start_discovery_page():
             match_and_store_keys(raw_text)
             return
         # Sprache der Quelle grob erkennen (Deutsch vs. Englisch)
-        sample = raw_text[:500].lower()
-        if sample.count(" der ") + sample.count(" die ") + sample.count(
-            " und "
-        ) > sample.count(" the "):
-            st.session_state["source_language"] = "Deutsch"
-        else:
-            st.session_state["source_language"] = "English"
+        from utils.lang_utils import detect_language
+
+        lang_code = detect_language(raw_text)
+        st.session_state["source_language"] = (
+            "Deutsch" if lang_code == "de" else "English"
+        )
         # Rohtext im Session State speichern & KI-Analyse durchführen
         st.session_state["parsed_data_raw"] = raw_text
         try:

--- a/tests/test_lang_utils.py
+++ b/tests/test_lang_utils.py
@@ -1,0 +1,11 @@
+from utils.lang_utils import detect_language
+
+
+def test_detect_language_english() -> None:
+    text = "This is a simple English sentence about a job description."
+    assert detect_language(text) == "en"
+
+
+def test_detect_language_german() -> None:
+    text = "Dies ist ein einfacher deutscher Satz über eine Stellenanzeige und die Aufgaben."
+    assert detect_language(text) == "de"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,4 @@
 from .text_cleanup import clean_text
+from .lang_utils import detect_language
 
-__all__ = ["clean_text"]
+__all__ = ["clean_text", "detect_language"]

--- a/utils/lang_utils.py
+++ b/utils/lang_utils.py
@@ -1,0 +1,21 @@
+"""Utility helpers related to language handling."""
+
+from __future__ import annotations
+
+
+__all__ = ["detect_language"]
+
+
+def detect_language(text: str) -> str:
+    """Detect whether *text* is German or English.
+
+    This simple heuristic checks for common stop words in lowercased text
+    and returns ``"de"`` for German or ``"en"`` for English.
+    In ambiguous cases English is returned.
+    """
+    if not isinstance(text, str):
+        return "en"
+    sample = text.lower()[:500]
+    german_score = sample.count(" der ") + sample.count(" die ") + sample.count(" und ")
+    english_score = sample.count(" the ") + sample.count(" and ") + sample.count(" of ")
+    return "de" if german_score > english_score else "en"


### PR DESCRIPTION
## Summary
- implement `utils.lang_utils.detect_language` to guess German vs English text
- expose new helper via `utils.__init__`
- use helper in wizard when detecting source language
- add unit tests for language detection

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f403497f483208bfe89ff2aea9edc