### PR TITLE
Switch to Responses API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Streamlit smoke test – streamlit run app.py --server.headless true in GitHub A
 
 Lint / Type-check – flake8 + black --check + mypy .
 
-Remember to mock the OpenAI module (unittest.mock.patch("openai.ChatCompletion.create", …)).
+Remember to mock the OpenAI module (unittest.mock.patch("openai.responses.create", …)).
 
 10 · Contributing checklist
  New tool decorated with @tool, documented here

--- a/logic/processors.py
+++ b/logic/processors.py
@@ -36,13 +36,14 @@ def update_task_list(state: dict[str, Any]) -> None:
     prompt += ".\n- "
     try:
         response = call_with_retry(
-            openai.chat.completions.create,
+            openai.responses.create,
             model=_SUGGESTION_MODEL,
-            messages=[{"role": "user", "content": prompt}],
+            instructions=None,
+            input=prompt,
             temperature=0.3,
-            max_tokens=100,
+            max_output_tokens=100,
         )
-        tasks_text = response.choices[0].message.content.strip()
+        tasks_text = response.output_text.strip()
     except Exception as e:
         logging.error(f"Task list suggestion failed: {e}")
         return
@@ -71,13 +72,14 @@ def update_must_have_skills(state: dict[str, Any]) -> None:
     prompt += "\n- "
     try:
         response = call_with_retry(
-            openai.chat.completions.create,  # type: ignore[attr-defined]
+            openai.responses.create,  # type: ignore[attr-defined]
             model=_SUGGESTION_MODEL,
-            messages=[{"role": "user", "content": prompt}],
+            instructions=None,
+            input=prompt,
             temperature=0.3,
-            max_tokens=100,
+            max_output_tokens=100,
         )
-        skills_text = response.choices[0].message.content.strip()
+        skills_text = response.output_text.strip()
     except Exception as e:
         logging.error(f"Must-have skills suggestion failed: {e}")
         return
@@ -106,13 +108,14 @@ def update_nice_to_have_skills(state: dict[str, Any]) -> None:
     prompt += "\n- "
     try:
         response = call_with_retry(
-            openai.chat.completions.create,  # type: ignore[attr-defined]
+            openai.responses.create,  # type: ignore[attr-defined]
             model=_SUGGESTION_MODEL,
-            messages=[{"role": "user", "content": prompt}],
+            instructions=None,
+            input=prompt,
             temperature=0.3,
-            max_tokens=60,
+            max_output_tokens=60,
         )
-        extra_skills = response.choices[0].message.content.strip()
+        extra_skills = response.output_text.strip()
     except Exception as e:
         logging.error(f"Nice-to-have skills suggestion failed: {e}")
         return
@@ -147,16 +150,14 @@ def update_salary_range(state: dict[str, Any]) -> None:
     )
     try:
         response = call_with_retry(
-            openai.chat.completions.create,  # type: ignore[attr-defined]
+            openai.responses.create,  # type: ignore[attr-defined]
             model=_SUGGESTION_MODEL,
-            messages=[
-                {"role": "system", "content": "You are a labour-market analyst."},
-                {"role": "user", "content": prompt},
-            ],
+            instructions="You are a labour-market analyst.",
+            input=prompt,
             temperature=0.2,
-            max_tokens=40,
+            max_output_tokens=40,
         )
-        result = response.choices[0].message.content.strip()
+        result = response.output_text.strip()
     except Exception as e:
         logging.error(f"Salary range estimation failed: {e}")
         return

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -11,10 +11,10 @@ with patch.object(st_secrets.Secrets, "_parse", return_value={}):
 def test_suggest_additional_skills_parses_output() -> None:
     fake_content = "Technical Skills:\n- Python\n- SQL\nSoft Skills:\n- Leadership\n- Communication"
     fake_resp = Mock()
-    fake_resp.choices = [Mock(message=Mock(content=fake_content))]
+    fake_resp.output_text = fake_content
 
     with patch(
-        "utils.llm_utils.openai.chat.completions.create",
+        "utils.llm_utils.openai.responses.create",
         return_value=fake_resp,
     ):
         result = suggest_additional_skills("Engineer")

--- a/utils/config.py
+++ b/utils/config.py
@@ -21,7 +21,7 @@ LANGUAGE = os.getenv("LANGUAGE", "en")
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-4o")
 VECTOR_STORE_PATH = os.getenv("VECTOR_STORE_PATH", "./vector_store")
 
-# OpenAI Modell für ChatCompletion (mit Function Calling)
+# OpenAI Modell für die Responses API (mit integrierten Tools)
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", DEFAULT_MODEL)
 # OpenAI API Key aus .env oder Streamlit Secrets
 # Surrounding quotes in `.env` will be trimmed automatically

--- a/utils/summarize.py
+++ b/utils/summarize.py
@@ -22,13 +22,14 @@ def summarize_text(text: str, quality: str = "standard") -> str:
     )
     try:
         response = call_with_retry(
-            openai.chat.completions.create,  # type: ignore[attr-defined]
+            openai.responses.create,  # type: ignore[attr-defined]
             model=config.OPENAI_MODEL,
-            messages=[{"role": "user", "content": prompt}],
+            instructions=None,
+            input=prompt,
             temperature=temperature,
-            max_tokens=300,
+            max_output_tokens=300,
         )
-        return response.choices[0].message.content.strip()
+        return response.output_text.strip()
     except Exception as err:
         logger.error("summarize_text failed: %s", err)
         return ""

--- a/utils/tool_registry.py
+++ b/utils/tool_registry.py
@@ -6,7 +6,7 @@ Originally from `src/utils/tool_registry.py`.
 Zentrale Sammlung aller @tool-dekorierten Funktionen.
 
 • @tool(...) registriert eine Funktion samt OpenAI-Schema
-• list_openai_functions() liefert die Schemaliste für ChatCompletion
+• list_openai_functions() liefert die Schemaliste für die Responses API
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- update agent and utils to use `openai.responses` instead of Chat Completions
- adjust docs and tests for new API usage
- clean up mypy errors with ignores

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4356d524832085b865f7894bdd9a