### PR TITLE
Fix config secrets handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ DATABASE_URL = "postgresql://user:pass@host/db"
 Replace `YOUR_OPENAI_KEY` with your actual key or set the
 `OPENAI_API_KEY` environment variable. Streamlit will read the
 environment variable when the key is not present in `secrets.toml`.
-Without a valid API key the wizard falls back to simple label parsing
-instead of AI-powered extraction.
+If no `secrets.toml` is provided the application still starts and
+defaults to the values from `.env` or the environment. Without a valid
+API key the wizard falls back to simple label parsing instead of
+AI-powered extraction.
 
 ## Running the App
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -30,8 +30,12 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "").strip("\"' ")
 SALARY_ESTIMATION_MODEL = os.getenv("SALARY_ESTIMATION_MODEL", "gpt-4o-mini")
 
 # Übernahme aus Streamlit Secrets (falls vorhanden)
-if "openai" in st.secrets:
-    secrets_data = st.secrets["openai"]
+try:
+    secrets_data = st.secrets.get("openai")
+except st.errors.StreamlitSecretNotFoundError:
+    secrets_data = None
+
+if secrets_data:
     # API-Key
     if secrets_data.get("OPENAI_API_KEY"):
         OPENAI_API_KEY = secrets_data["OPENAI_API_KEY"]


### PR DESCRIPTION
## Summary
- avoid crash when no Streamlit secrets are configured
- clarify README about secrets fallback

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68503457080c83208343944c693b2ecf