### PR TITLE
feat: add navigation helpers

### DIFF
--- a/components/wizard.py
+++ b/components/wizard.py
@@ -58,6 +58,18 @@ def _clamp_step() -> int:
     return st.session_state["wizard_step"]
 
 
+def next_step() -> None:
+    """Increment the current wizard step while staying within bounds."""
+    st.session_state["wizard_step"] = _clamp_step() + 1
+    _clamp_step()
+
+
+def previous_step() -> None:
+    """Decrement the current wizard step while staying within bounds."""
+    st.session_state["wizard_step"] = _clamp_step() - 1
+    _clamp_step()
+
+
 def _int_from_state(key: str, default: int) -> int:
     """Safely parse an int from session state or return the default."""
     val = st.session_state.get(key)
@@ -1260,7 +1272,7 @@ def _nav(step: int) -> None:
     if step < 8:
         st.button(
             "Weiter" if lang == "Deutsch" else "Next",
-            on_click=lambda: st.session_state.update({"wizard_step": step + 1}),
+            on_click=next_step,
             key=f"next_{step}",
         )
     if step > 1:
@@ -1271,6 +1283,6 @@ def _nav(step: int) -> None:
         )
         st.button(
             "Zurück" if lang == "Deutsch" else "Back",
-            on_click=lambda: st.session_state.update({"wizard_step": step - 1}),
+            on_click=previous_step,
             key=f"back_{step}",
         )

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+import streamlit.runtime.secrets as st_secrets
+
+with patch.object(st_secrets.Secrets, "_parse", return_value={}):
+    from components.wizard import next_step, previous_step
+    import streamlit as st
+
+
+def test_next_previous_step() -> None:
+    st.session_state.clear()
+    st.session_state["wizard_step"] = 1
+    next_step()
+    assert st.session_state["wizard_step"] == 2
+    previous_step()
+    assert st.session_state["wizard_step"] == 1


### PR DESCRIPTION
## Summary
- expose helper functions `next_step` and `previous_step`
- use helpers in navigation button callbacks
- cover navigation logic in unit tests

## Testing
- `pytest -q`
- `ruff check .`
- `black --check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68503d02de408320a6aa2ec6721fce00